### PR TITLE
[SE-3950] Add a waffle flag to ignore the accept-language header

### DIFF
--- a/analytics_dashboard/core/middleware.py
+++ b/analytics_dashboard/core/middleware.py
@@ -8,8 +8,22 @@ from lang_pref_middleware import middleware
 from django.template.response import TemplateResponse
 
 from core.exceptions import ServiceUnavailableError
+from waffle import flag_is_active
 
 logger = logging.getLogger(__name__)
+
+
+# For https://tasks.opencraft.com/browse/SE-3950 . If an upstream solution is invented by the time you're rebasing this,
+# remove it and the line that includes it from the middleware settings.
+class LanguageHeaderPreemptMiddleware(object):
+    """
+    If the appropriate waffle flag is present, ignore the 'Accept-Language' header.
+    """
+    def process_request(self, request):
+        if not flag_is_active(request, 'analytics_dashboard.ignore_accept_language'):
+            return
+        if request.META.has_key('HTTP_ACCEPT_LANGUAGE'):
+            del request.META['HTTP_ACCEPT_LANGUAGE']
 
 
 class LanguagePreferenceMiddleware(middleware.LanguagePreferenceMiddleware):

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -175,6 +175,7 @@ TEMPLATES = [
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#middleware-classes
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'core.middleware.LanguageHeaderPreemptMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
This pull request adds a piece of middleware, controlled via waffle flag, to remove the Accept-Language header from a request so that LANGUAGE_CODE is set as the default language in the event no cookie is set.

**JIRA tickets**: https://tasks.opencraft.com/browse/SE-3950

**Testing instructions**:

1. Clone the repository if you have not done so already.
2. Create a virtualenv with Python 2.7 and activate it.
3. Follow the installation instructions in the README.
4. Set ALLOWED_HOSTS to ['*'] to make things easier on yourself while testing.
4. Change the LANGUAGE_CODE setting to a language you'd prefer.
5. Use runserver. Observe that the language header is still respected.
6. Set the waffle flag with `./manage.py waffle_flag ignore_accept_language --everyone --create`
7. Reload the page and verify the language has changed.

**Author notes and concerns**:

Up until this point, Campus has not customized insights. They were running off of edx's `open-release/ginkgo-master` branch. This changes that to run off of this repository here, and so that will need to be reflected in configuration changes.

We may be able to upstream a change like this, but the code will almost certainly be different-- the way Middleware is handled by Django upstream changed significantly several versions since.

**Reviewers**
- [ ] @nizarmah 